### PR TITLE
Modify list api endpoint

### DIFF
--- a/src/thermador/data/migration/page.clj
+++ b/src/thermador/data/migration/page.clj
@@ -6,14 +6,9 @@
 
 (defn make-title-from-md-file-name
   [md]
-  (let [words (-> md
-                  (str/split #"\.")
-                  (first)
-                  (str/split #"_"))]
-    (->> words
-         (map str/capitalize)
-         (interpose " ")
-         (apply str))))
+  (-> md
+      (str/split #"\.")
+      (first)))
 
 (defn create-page-from-markdown-text
   [name markdown]

--- a/src/thermador/rest.clj
+++ b/src/thermador/rest.clj
@@ -57,7 +57,7 @@
    :body (slurp (io/resource "404.html"))})
 
 (defroutes rest-routes
-  (GET "/:resource/list" [resource] (api-result resource "list"))
+  (GET "/:resource/-list" [resource] (api-result resource "list"))
   (GET "/:resource/:id" [resource id] (api-result resource "get" id))
   (GET "/:resource" [resource] (api-result resource))
   (ANY "*" [] (route/not-found (slurp (io/resource "404.html")))))


### PR DESCRIPTION
1. Don't use the plain word "list"; don't conflict
2. Make page names and titles all same-same